### PR TITLE
Issue 1-5: add check button with correctness feedback

### DIFF
--- a/app/javascript/controllers/cell_controller.js
+++ b/app/javascript/controllers/cell_controller.js
@@ -1,6 +1,70 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
+  static targets = ["cell", "feedback"]
+
+  answerKey() {
+  // Demo-only: 5x5 grid indices 0..24. Use "#" to represent blocked squares.
+    return [
+      "H", "E", "L", "L", "O",
+      "#", "#", "A", "#", "#",
+      "W", "O", "R", "L", "D",
+      "#", "#", "I", "#", "#",
+      "R", "A", "I", "L", "S",
+    ]
+  }
+
+  cells() {
+  // Prefer scoping to this controller’s element (safer than document-wide)
+    return Array.from(this.element.querySelectorAll('input[data-row][data-col]'))
+  }
+
+  check() {
+    const key = this.answerKey()
+    const inputs = this.cells()
+
+    let wrong = 0
+    let checked = 0
+
+    inputs.forEach((input) => {
+      const r = parseInt(input.dataset.row, 10)
+      const c = parseInt(input.dataset.col, 10)
+      const idx = r * 5 + c
+
+      const expected = key[idx]
+      if (!expected || expected === "#") return
+
+      checked += 1
+
+      const actual = (input.value || "").toUpperCase()
+
+      // Clear prior state (IMPORTANT: remove border-transparent too)
+      input.classList.remove("border-green-500", "border-red-500", "border-transparent")
+
+      // Skip unfilled cells — no hints yet
+      if (!actual) {
+        input.classList.add("border-transparent")
+        return
+      }
+
+      if (actual && actual === expected) {
+        input.classList.add("border-green-500")
+      } else {
+        input.classList.add("border-red-500")
+        wrong += 1
+      }
+    })
+
+    if (this.hasFeedbackTarget) {
+      if (checked === 0) {
+        this.feedbackTarget.textContent = "Fill some letters, then check."
+      } else if (wrong === 0) {
+        this.feedbackTarget.textContent = "✅ Looks good so far!"
+      } else {
+        this.feedbackTarget.textContent = `❌ ${wrong} incorrect.`
+      }
+    }
+  }
 
   input(event) {
     let value = event.target.value

--- a/app/views/puzzles/demo.html.erb
+++ b/app/views/puzzles/demo.html.erb
@@ -1,25 +1,45 @@
+<%# app/views/puzzles/demo.html.erb %>
+<!-- Tailwind safelist for JS-added classes (demo-only) -->
+<div class="hidden border-green-500 border-red-500 border-transparent border-2"></div>
+
 <h1 class="text-2xl font-semibold mb-4">PlumaFill — Demo</h1>
 
-<div class="grid grid-cols-5 gap-1 w-fit">
-  <% 25.times do |index| %>
-    <% idx = index.to_i %>
-    <% blocked = [6, 7, 8, 16, 17, 18].include?(idx) %>
-    <% row = idx / 5 %>
-    <% col = idx % 5 %>
+<div data-controller="cell">
+  <div class="grid grid-cols-5 gap-1 w-fit">
+    <% 25.times do |index| %>
+      <% idx = index.to_i %>
+      <% blocked = [6, 7, 8, 16, 17, 18].include?(idx) %>
+      <% row = idx / 5 %>
+      <% col = idx % 5 %>
 
-    <div class="w-12 h-12 border flex items-center justify-center text-lg font-bold <%= blocked ? 'bg-black' : 'bg-white' %>">
-      <% unless blocked %>
-      <input
-        type="text"
-        maxlength="1"
-        class="w-full h-full text-center text-lg font-bold uppercase outline-none bg-transparent"
-        data-controller="cell"
-        data-action="input->cell#input keydown->cell#keydown"
-        data-row="<%= row %>"
-        data-col="<%= col %>"
-        aria-label="Cell <% idx %>"
-        />   
-      <% end %>
-    </div>
-  <% end %>
+      <div class="w-12 h-12 border flex items-center justify-center text-lg font-bold <%= blocked ? 'bg-black' : 'bg-white' %>">
+        <% unless blocked %>
+        <input
+          type="text"
+          maxlength="1"
+          class="w-full h-full text-center text-lg font-bold uppercase outline-none bg-transparent border-2 border-transparent"
+          data-controller="cell"
+          data-action="input->cell#input keydown->cell#keydown"
+          data-row="<%= row %>"
+          data-col="<%= col %>"
+          aria-label="Cell <% idx %>"
+          />   
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="mt-4 flex items-center gap-3">
+    <button
+      type="button"
+      class="rounded bg-slate-800 px-4 py-2 text-white hover:bg-slate-700"
+      data-action="click->cell#check"
+    >
+      Check
+    </button>
+
+    <p class="text-sm text-slate-700" data-cell-target="feedback"></p>
+  </div>
 </div>
+                
+


### PR DESCRIPTION
## Summary
Adds a demo “Check” button with basic correctness feedback for filled cells.

## Related Issue
Closes #9 

## Changes
- Added Check button and feedback area
- Hardcoded demo answer key
- Marked filled cells correct/incorrect without revealing blanks

## Verification
- [x] Manual test: filled cells show green/red
- [x] Blank cells remain neutral
