### PR TITLE
Issue 1-6: add clear/reset button for demo grid

### DIFF
--- a/app/javascript/controllers/cell_controller.js
+++ b/app/javascript/controllers/cell_controller.js
@@ -66,6 +66,26 @@ export default class extends Controller {
     }
   }
 
+  clear() {
+    const inputs = this.cells()
+
+    inputs.forEach((input) => {
+      input.value = ""
+      input.classList.remove("border-green-500", "border-red-500", "border-transparent")
+      input.classList.add("border-transparent")
+    })
+
+    if (this.hasFeedbackTarget) {
+      this.feedbackTarget.textContent = ""
+    }
+
+    // Put the cursor back at the first playable cell
+    if (inputs.length > 0) {
+      inputs[0].focus()
+      inputs[0].select()
+    }
+  }
+
   input(event) {
     let value = event.target.value
 

--- a/app/views/puzzles/demo.html.erb
+++ b/app/views/puzzles/demo.html.erb
@@ -37,6 +37,13 @@
     >
       Check
     </button>
+    <button
+      type="button"
+      class="rounded border border-slate-400 px-4 py-2 text-slate-700 hover:bg-slate-100"
+      data-action="click->cell#clear"      
+    >
+      Clear
+    </button>
 
     <p class="text-sm text-slate-700" data-cell-target="feedback"></p>
   </div>


### PR DESCRIPTION
## Summary
Add Clear / Reset control to the demo puzzle grid.

## Related Issue
Closes #31 

## Changes
- Add Clear button next to Check
- Reset all cell values, borders, and feedback
- Return focus to first cell

## Verification
- Manual smoke test: clear resets grid without errors
