### PR TITLE
Issue 2-2: derive across and down slots with cell coordinates

### DIFF
--- a/app/controllers/puzzles_controller.rb
+++ b/app/controllers/puzzles_controller.rb
@@ -1,5 +1,6 @@
 class PuzzlesController < ApplicationController
   def demo
     @grid = PuzzleDemo.grid
+    @slots = PuzzleDemo.slots(@grid)
   end
 end

--- a/app/models/puzzle_demo.rb
+++ b/app/models/puzzle_demo.rb
@@ -9,4 +9,52 @@ class PuzzleDemo
       [ "B", "I", "R", "D", "S", "E", "E" ]
     ]
   end
+
+  def self.slots(grid = self.grid)
+    slots = []
+    rows = grid.length
+    cols = grid.first.length
+
+    rows.times do |r|
+      cols.times do |c|
+        next if grid[r][c].nil?
+
+        # Across slot start: left is blocked/out-of-bounds
+        if c == 0 || grid[r][c-1].nil?
+          length = 0
+          while (c + length) < cols && !grid[r][c + length].nil?
+            length += 1
+          end
+
+          cells = (0...length).map { |offset| [r, c + offset] }
+          slots << {
+            orientation: "across",
+            row: r,
+            col: c,
+            length: length,
+            cells: cells
+          } if length > 1
+        end
+
+        # Down slot start: above is blocked/out-of-bounds
+        if r == 0 || grid[r - 1][c].nil?
+          length = 0
+          while (r + length) < rows && !grid[r + length][c].nil?
+            length += 1
+          end
+
+          cells = (0...length).map { |offset| [r + offset, c] }
+          slots << {
+            orientation: "down",
+            row: r,
+            col: c,
+            length: length,
+            cells: cells
+          } if length > 1
+        end
+      end
+    end
+
+    slots
+  end
 end


### PR DESCRIPTION
## Summary
Derive across and down puzzle slots programmatically from the puzzle grid and expose slot metadata for downstream validation and highlighting logic.

## Related Issue
Closes #11 

## Changes
- Added slot derivation logic to `PuzzleDemo` based on grid data
- Identified across and down slot start positions programmatically
- Computed slot length and orientation without hard-coded dimensions
- Added explicit cell coordinate lists for each slot
- Exposed derived slots to the demo controller for inspection and future use

## Verification
- [ ] Across slots detected correctly from grid data
- [ ] Down slots detected correctly from grid data
- [ ] Slot length matches contiguous non-blocked cells
- [ ] Slot cell coordinates are accurate and ordered
- [ ] No 1-letter slots generated

## Notes
This PR is a logic-only enhancement. No UI changes, persistence, validation rules, or gameplay behavior were added.
