### PR TITLE
Issue 2-3: add slot and puzzle validation logic

### DIFF
--- a/app/models/puzzle_demo.rb
+++ b/app/models/puzzle_demo.rb
@@ -57,4 +57,49 @@ class PuzzleDemo
 
     slots
   end
+
+  def self.slot_id(slot)
+    "#{slot[:orientation]}_#{slot[:row]}_#{slot[:col]}"
+  end
+
+  def self.validate_slots(user_grid, grid = self.grid)
+    slot_states = {}
+
+    self.slots.each do |slot|
+      cells = slot[:cells]
+
+      any_blank = cells.any? { |r, c| user_grid.dig(r, c).to_s.strip.empty? }
+
+      if any_blank
+        slot_states[slot_id(slot)] = :incomplete
+        next
+      end
+
+      any_wrong = cells.any? do |r, c|
+        expected = grid.dig(r, c).to_s.upcase
+        actual   = user_grid.dig(r, c).to_s.upcase
+        expected != actual
+      end
+
+      slot_states[slot_id(slot)] = any_wrong ? :incorrect : :correct
+    end
+
+    puzzle_state =
+      if slot_states.value?(:incomplete)
+        :incomplete
+      elsif slot_states.value?(:incorrect)
+        :incorrect
+      else
+        :correct
+      end
+
+    {
+      slots: slot_states,
+      puzzle_state: puzzle_state
+    }
+  end
+
+  def self.puzzle_state(user_grid, grid = self.grid)
+    validate_slots(user_grid, grid)[:puzzle_state]
+  end
 end


### PR DESCRIPTION
## Summary
Adds slot-based validation logic to the puzzle model, enabling correct, incorrect, and incomplete states at both the slot and full-puzzle level.

## Related Issue
Closes #12 

## Changes
- Added slot-level validation to `PuzzleDemo`
- Implemented per-slot states (`:correct`, `:incorrect`, `:incomplete`)
- Derived overall puzzle state from slot states
- Introduced stable slot identifiers
- Added convenience method for full puzzle state lookup

## Verification
- [x] Incomplete grid returns `:incomplete`
- [x] Fully correct grid returns `:correct`
- [x] Any incorrect slot returns `:incorrect`
- [x] Verified via Rails console
